### PR TITLE
Feature/remove custom bool definitions

### DIFF
--- a/src/core/input/keyboard.c
+++ b/src/core/input/keyboard.c
@@ -42,7 +42,7 @@ static int keyboardInputListener(void *data, SDL_Event *event) {
         logVerbose("Key event captured | event type %u | key scancode %d", eventType, keyEvent->keysym.scancode);
 
         if(keyEvent->repeat == 0) {
-            setKeyState(keyEvent->keysym.scancode, bool_cast(eventType == SDL_KEYDOWN));
+            setKeyState(keyEvent->keysym.scancode, eventType == SDL_KEYDOWN);
         }
     }
 

--- a/src/include/definitions/global.h
+++ b/src/include/definitions/global.h
@@ -1,20 +1,8 @@
 #ifndef _DIDATIC_GAME_DEFINITIONS_GLOBAL_H_
 #define _DIDATIC_GAME_DEFINITIONS_GLOBAL_H_
 
+#include <stdbool.h>
+
 #define UNUSED(x) (void)x
-
-#ifndef bool
-    #define bool int
-#endif // bool
-
-#ifndef true
-    #define true 1
-#endif // true
-
-#ifndef false
-    #define false 0
-#endif // false
-
-#define bool_cast(x) x ? true : false
 
 #endif // _DIDATIC_GAME_DEFINITIONS_GLOBAL_H_


### PR DESCRIPTION
# Description
Removing some custom definitions for true, false, bool and bool_cast. I'm using now stdbool.h instead and its definition of true, false and bool for better compatibility between platforms.