### PR TITLE
Improving build.bat to avoid missing .dll while running gcc

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -23,6 +23,9 @@ IF EXIST %BUILD_CFG_FILE% (
     EXIT /B
 )
 
+REM Setting up PATH to avoid missing .dll while running gcc.exe
+set PATH=%PATH%;%TOOLCHAIN_PATH%
+
 REM Setting up build configurations
 set BUILD_COMPILE_FLAGS=-O2
 set BUILD_LINKING_FLAGS=-mwindows


### PR DESCRIPTION
# Description
Some windows enviroments lack some .dll that gcc depends on. The build.bat was improved to temporarily add the toolchain path to the PATH env so gcc.exe finds all .dll it needs