### PR TITLE
Add Munit test framework

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "munit"]
+	path = munit
+	url = https://github.com/nemequ/munit.git

--- a/build.bat
+++ b/build.bat
@@ -49,7 +49,9 @@ echo compiler flags: %BUILD_COMPILE_FLAGS%
 echo linking flags: %BUILD_LINKING_FLAGS%
 echo ----------------------------------------
 
-REM Compilation
+REM Game binary building
+
+REM Game binary compilation
 %TOOLCHAIN_PATH%\%C_COMPILER% -c src\core\main.c -I%LIBSDL_PATH%\include\SDL2 -I%LIBSDLTTF_PATH%\include\SDL2 -Isrc\include %BUILD_COMPILE_FLAGS% -Wall -Wextra -Werror -std=c17 -o build\%BUILD_MODE%\main.o
 %TOOLCHAIN_PATH%\%C_COMPILER% -c src\utils\log\log.c -I%LIBSDL_PATH%\include\SDL2 -I%LIBSDLTTF_PATH%\include\SDL2 -Isrc\include %BUILD_COMPILE_FLAGS% -Wall -Wextra -Werror -std=c17 -o build\%BUILD_MODE%\log.o
 %TOOLCHAIN_PATH%\%C_COMPILER% -c src\core\input\events.c -I%LIBSDL_PATH%\include\SDL2 -I%LIBSDLTTF_PATH%\include\SDL2 -Isrc\include %BUILD_COMPILE_FLAGS% -Wall -Wextra -Werror -std=c17 -o build\%BUILD_MODE%\events.o
@@ -57,14 +59,32 @@ REM Compilation
 %TOOLCHAIN_PATH%\%C_COMPILER% -c src\core\video\video.c -I%LIBSDL_PATH%\include\SDL2 -I%LIBSDLTTF_PATH%\include\SDL2 -Isrc\include %BUILD_COMPILE_FLAGS% -Wall -Wextra -Werror -std=c17 -o build\%BUILD_MODE%\video.o
 %TOOLCHAIN_PATH%\%C_COMPILER% -c src\core\video\window.c -I%LIBSDL_PATH%\include\SDL2 -I%LIBSDLTTF_PATH%\include\SDL2 -Isrc\include %BUILD_COMPILE_FLAGS% -Wall -Wextra -Werror -std=c17 -o build\%BUILD_MODE%\window.o
 
-REM Linking
+REM Game binary linking
 %TOOLCHAIN_PATH%\%C_COMPILER% build\%BUILD_MODE%\main.o build\%BUILD_MODE%\log.o build\%BUILD_MODE%\events.o build\%BUILD_MODE%\keyboard.o build\%BUILD_MODE%\video.o build\%BUILD_MODE%\window.o -L%LIBSDL_PATH%\lib -L%LIBSDLTTF_PATH%\lib %BUILD_LINKING_FLAGS% -lmingw32 -lSDL2main -lSDL2 -lSDL2_ttf -o build\%BUILD_MODE%\brenoGame.exe
+
+REM Tests build cleanup
+rmdir /S /Q build\tests
+mkdir build\tests
+
+REM Tests building
+
+REM Tests compilation
+set TEST_COMPILATION_PARAMS=-g -Wall -Wextra -Werror -Wno-implicit-function-declaration -std=c17
+%TOOLCHAIN_PATH%\%C_COMPILER% -c munit\munit.c -Imunit %TEST_COMPILATION_PARAMS% -o build\tests\munit.o
+%TOOLCHAIN_PATH%\%C_COMPILER% -c tests\main.c -Imunit %TEST_COMPILATION_PARAMS% -o build\tests\main.o
+%TOOLCHAIN_PATH%\%C_COMPILER% -c tests\core\video\window_tests.c -Imunit %TEST_COMPILATION_PARAMS% -o build\tests\window_tests.o
+
+REM Tests linking
+%TOOLCHAIN_PATH%\%C_COMPILER% build\tests\main.o build\tests\munit.o build\tests\window_tests.o -L%LIBSDL_PATH%\lib -L%LIBSDLTTF_PATH%\lib -mconsole -lmingw32 -lSDL2main -lSDL2 -lSDL2_ttf -o build\tests\tests.exe
 
 REM Installation cleanup
 rmdir /S /Q install\%BUILD_MODE%
 mkdir install\%BUILD_MODE%
 mkdir install\%BUILD_MODE%\res
 mkdir install\%BUILD_MODE%\res\fonts
+
+rmdir /S /Q install\tests
+mkdir install\tests
 
 REM Installing
 REM Moving build binary and needed libraries
@@ -74,3 +94,6 @@ copy /B /Y build\%BUILD_MODE%\brenoGame.exe install\%BUILD_MODE%
 
 REM Moving resources files
 copy /B /Y resources\fonts\*.ttf install\%BUILD_MODE%\res\fonts
+
+REM Moving test binary
+copy /B /Y build\tests\tests.exe install\tests

--- a/tests/core/video/window_tests.c
+++ b/tests/core/video/window_tests.c
@@ -1,0 +1,36 @@
+#include <munit.h>
+
+static MunitResult windowGetScreenUninitedVideo(const MunitParameter params[], void* user_data_or_fixture);
+
+static MunitTest windowTests[] = {
+    {
+        "/windowGetScreen-unitializedVideo",
+        windowGetScreenUninitedVideo,
+        NULL,
+        NULL,
+        MUNIT_TEST_OPTION_NONE,
+        NULL
+    },
+
+    // Ending of tests array
+    { NULL, NULL, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL }
+};
+
+static MunitSuite windowTestsSuite = {
+    "/core/video/window",
+    windowTests,
+    NULL,
+    1,
+    MUNIT_SUITE_OPTION_NONE
+};
+
+static MunitResult windowGetScreenUninitedVideo(const MunitParameter params[], void* user_data_or_fixture) {
+    (void)params;
+    (void)user_data_or_fixture;
+
+    return MUNIT_FAIL;
+}
+
+MunitSuite windowTestsGetSuite(void) {
+    return windowTestsSuite;
+}

--- a/tests/main.c
+++ b/tests/main.c
@@ -1,0 +1,3 @@
+int main(int argc, char *argv[]) {
+    return 0;
+}

--- a/tests/main.c
+++ b/tests/main.c
@@ -1,3 +1,20 @@
+#include <munit.h>
+
+MunitSuite windowTestsGetSuite(void);
+
+#define TEST_SUITES_NUMBER 1
+static MunitSuite allTestSuites[TEST_SUITES_NUMBER];
+
+static const MunitSuite suite = {
+    "/game",
+    NULL,
+    allTestSuites,
+    1,
+    MUNIT_SUITE_OPTION_NONE
+};
+
 int main(int argc, char *argv[]) {
-    return 0;
+    allTestSuites[0] = windowTestsGetSuite();
+
+    return munit_suite_main(&suite, NULL, argc, argv);
 }


### PR DESCRIPTION
# Description
Adding a C unit test framework to the project. This merge contains commits with an example of how to implement unit test for the munit framework. This example will be removed later when unit tests start being implemented for real.
  
To facilitate the unit tests creation, only modules that do not have external dependencies (for example for SDL library) will have unit tests implemented. We need some mocking up archtecture to implement unit tests for modules that have external dependencies that I do not intend to have in this project to keep it simple and didatic

# Test output layout example
```
Running test suite with seed 0x15534978...
/game/core/video/window/windowGetScreen-unitializedVideo[ FAIL  ]
0 of 1 (0%) tests successful, 0 (0%) test skipped.
```